### PR TITLE
Docker 1.10.0 Networks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,34 +1,38 @@
-ambassador:
-    image: cpuguy83/docker-grand-ambassador
-    volumes:
-        - /var/run/docker.sock:/run/docker.sock
-    command: "-name tykquickstart_tyk_gateway_1 -name tykquickstart_tyk_dashboard_1"
-tyk_gateway:
-    image: tykio/tyk-gateway:latest
-    links:
-        - tyk_redis:redis
-        - tyk_mongo:mongo
-        - ambassador:tyk_dashboard
-    ports:
-        - "80:8080"
-        - "8080:8080"
-    volumes:
-        - ./tyk.conf:/opt/tyk-gateway/tyk.conf
-tyk_dashboard:
-    image: tykio/tyk-dashboard:latest
-    links:
-        - tyk_redis:redis
-        - tyk_mongo:mongo
-        - tyk_gateway:tyk_gateway
-        - ambassador:tyk_gateway
-    ports:
-        - "3000:3000"
-    volumes:
-        - ./tyk_analytics.conf:/opt/tyk-dashboard/tyk_analytics.conf
-tyk_redis:
-    image: redis:latest
-    hostname: redis
-tyk_mongo:
-    image: mongo:latest
-    command: ["mongod", "--smallfiles"]
-    hostname: mongo
+version: '2'
+
+services:
+    tyk_gateway:
+        image: tykio/tyk-gateway:latest
+        ports:
+            - "80:8080"
+            - "8080:8080"
+        volumes:
+            - ./tyk.conf:/opt/tyk-gateway/tyk.conf
+        networks:
+            - gateway
+    tyk_dashboard:
+        image: tykio/tyk-dashboard:latest
+        ports:
+            - "3000:3000"
+        volumes:
+            - ./tyk_analytics.conf:/opt/tyk-dashboard/tyk_analytics.conf
+        networks:
+            - gateway
+    tyk_redis:
+        image: redis:latest
+        hostname: redis
+        networks:
+            gateway:
+                aliases:
+                    - redis
+    tyk_mongo:
+        image: mongo:latest
+        command: ["mongod", "--smallfiles"]
+        hostname: mongo
+        networks:
+            gateway:
+                aliases:
+                    - mongo
+
+networks:
+    gateway:

--- a/setup.sh
+++ b/setup.sh
@@ -10,14 +10,18 @@
 
 # OSX users will need to specify a virtual IP, linux users can use 127.0.0.1
 
+# Proxy
+TYK_DASHBOARD_DOMAIN="tyk_dashboard"
+
 # Tyk dashboard settings
 TYK_DASHBOARD_USERNAME="test$RANDOM@test.com"
 TYK_DASHBOARD_PASSWORD="test123"
 
 # Tyk portal settings
 TYK_PORTAL_DOMAIN="www.tyk-portal-test.com"
+TYK_PORTAL_PATH="/"
 
-DOCKER_IP=127.0.0.1
+DOCKER_IP="127.0.0.1"
 
 if [ -n "$DOCKER_HOST" ]
 then
@@ -64,6 +68,31 @@ OK=$(curl --silent --header "authorization: $USER_AUTH" --header "Content-Type:a
 
 echo "Setting up the portal domain"
 OK=$(curl --silent -d "domain="$TYK_PORTAL_DOMAIN"" -H "admin-auth:12345" http://$DOCKER_IP:3000/admin/organisations/$ORG_ID/generate-portals)
+
+echo "Setting up the Portal catalogue"
+CATALOGUE_DATA=$(curl --silent --header "Authorization: $USER_AUTH" --header "Content-Type:application/json" --data '{"org_id": "'$ORG_ID'"}' http://$DOCKER_IP:3000/api/portal/catalogue 2>&1)
+CATALOGUE_ID=$(echo $CATALOGUE_DATA | python -c 'import json,sys;obj=json.load(sys.stdin);print obj["Message"]')
+OK=$(curl --silent --header "Authorization: $USER_AUTH" http://$DOCKER_IP:3000/api/portal/catalogue 2>&1)
+
+echo "Setting target URL for Portal APIs"
+API_LIST=$(curl --silent --header "Authorization: $USER_AUTH" http://$DOCKER_IP:3000/api/apis 2>&1)
+API_PORTAL_DATA=$(echo $API_LIST | python -c 'import json,sys;obj=json.load(sys.stdin);print json.dumps(obj["apis"][2])')
+API_PORTAL_DATA=$(echo $API_PORTAL_DATA | python -c 'import json,sys;obj=json.load(sys.stdin);obj["sort_by"]=9;target_url=obj["api_definition"]["proxy"]["target_url"];obj["api_definition"]["proxy"]["target_url"]=target_url.replace("localhost", "'"$TYK_DASHBOARD_DOMAIN"'");print json.dumps(obj)')
+API_PORTAL_DATA=$(echo $API_PORTAL_DATA | python -c 'import json,sys;obj=json.load(sys.stdin);obj["api_definition"]["proxy"]["listen_path"]="'$TYK_PORTAL_PATH'";print json.dumps(obj)')
+API_PORTAL_ID=$(echo $API_PORTAL_DATA | python -c 'import json,sys;obj=json.load(sys.stdin);print obj["api_definition"]["id"]')
+API_PORTAL_API_DATA=$(echo $API_LIST | python -c 'import json,sys;obj=json.load(sys.stdin);print json.dumps(obj["apis"][1])')
+API_PORTAL_API_DATA=$(echo $API_PORTAL_API_DATA | python -c 'import json,sys;obj=json.load(sys.stdin);target_url=obj["api_definition"]["proxy"]["target_url"];obj["api_definition"]["proxy"]["target_url"]=target_url.replace("localhost", "'"$TYK_DASHBOARD_DOMAIN"'");print json.dumps(obj)')
+API_PORTAL_API_DATA=$(echo $API_PORTAL_API_DATA | python -c 'import json,sys;obj=json.load(sys.stdin);obj["api_definition"]["proxy"]["listen_path"]="/portal-api/";print json.dumps(obj)')
+API_PORTAL_API_ID=$(echo $API_PORTAL_API_DATA | python -c 'import json,sys;obj=json.load(sys.stdin);print obj["api_definition"]["id"]')
+API_PORTAL_ASSETS_DATA=$(echo $API_LIST | python -c 'import json,sys;obj=json.load(sys.stdin);print json.dumps(obj["apis"][0])')
+API_PORTAL_ASSETS_DATA=$(echo $API_PORTAL_ASSETS_DATA | python -c 'import json,sys;obj=json.load(sys.stdin);target_url=obj["api_definition"]["proxy"]["target_url"];obj["api_definition"]["proxy"]["target_url"]=target_url.replace("localhost", "'"$TYK_DASHBOARD_DOMAIN"'");print json.dumps(obj)')
+API_PORTAL_ASSETS_ID=$(echo $API_PORTAL_ASSETS_DATA | python -c 'import json,sys;obj=json.load(sys.stdin);print obj["api_definition"]["id"]')
+OK=$(curl --silent --header "Authorization: $USER_AUTH" --header "Content-Type:application/json" --data "$API_PORTAL_DATA" -X PUT http://$DOCKER_IP:3000/api/apis/$API_PORTAL_ID 2>&1)
+OK=$(curl --silent --header "Authorization: $USER_AUTH" --header "Content-Type:application/json" --data "$API_PORTAL_API_DATA" -X PUT http://$DOCKER_IP:3000/api/apis/$API_PORTAL_API_ID 2>&1)
+OK=$(curl --silent --header "Authorization: $USER_AUTH" --header "Content-Type:application/json" --data "$API_PORTAL_ASSETS_DATA" -X PUT http://$DOCKER_IP:3000/api/apis/$API_PORTAL_ASSETS_ID 2>&1)
+
+echo "Creating the Portal Home page"
+OK=$(curl --silent --header "Authorization: $USER_AUTH" --header "Content-Type:application/json" --data '{"is_homepage": true, "template_name":"", "title":"Tyk Developer Portal", "slug":"home", "fields": {"JumboCTATitle": "Tyk Developer Portal", "SubHeading": "Sub Header", "JumboCTALink": "#cta", "JumboCTALinkTitle": "Your awesome APIs, hosted with Tyk!", "PanelOneContent": "Panel 1 content.", "PanelOneLink": "#panel1", "PanelOneLinkTitle": "Panel 1 Button", "PanelOneTitle": "Panel 1 Title", "PanelThereeContent": "", "PanelThreeContent": "Panel 3 content.", "PanelThreeLink": "#panel3", "PanelThreeLinkTitle": "Panel 3 Button", "PanelThreeTitle": "Panel 3 Title", "PanelTwoContent": "Panel 2 content.", "PanelTwoLink": "#panel2", "PanelTwoLinkTitle": "Panel 2 Button", "PanelTwoTitle": "Panel 2 Title"}}' http://$DOCKER_IP:3000/api/portal/pages 2>&1)
 
 echo ""
 


### PR DESCRIPTION
Use Docker 1.10.0 networks instead of Ambassador. This requires Docker Compose 1.6.2 or later.

Improved the setup script to simplify setup for users:
- The correct target URL is set for the portal APIs automatically
- A homepage is created for the portal automatically, which means the portal URL printed in the setup script should work right away
- Empty catalogues is created for the organisation

This means setup should be as simple as:
1. Edit `/etc/hosts`
2. `docker-compose up -d`
3. `./setup.sh`
